### PR TITLE
feat: add reusable ReviewForm block component

### DIFF
--- a/src/lib/static-block-data.ts
+++ b/src/lib/static-block-data.ts
@@ -76,6 +76,8 @@ import Pricing_1 from "@/vaults/blocks/pricing/pricing-1";
 import Pricing_2 from "@/vaults/blocks/pricing/pricing-2";
 import Pricing_3 from "@/vaults/blocks/pricing/pricing-3";
 
+import ReviewForm_1 from "@/vaults/blocks/reviewform/reviewform-1";
+
 export interface BlockMetadata {
   id: string;
   name: string;
@@ -708,6 +710,15 @@ export const staticBlocksWithComponents: Record<string, BlockWithComponent> = {
       "https://res.cloudinary.com/dnrtsh66v/image/upload/v1750386367/Screenshot_2025-06-20_at_09.25.58_gg4hiu.png",
     component: Pricing_3,
   },
+  "reviewform-1": {
+    id: "reviewform-1",
+    name: "Customer Review Form",
+    description: 
+    "Review form with rating and comment input, great for e-commerce",
+    photo: 
+    "https://asset.cloudinary.com/milopy/cc35507e488effc231c4b047373756c0",
+    component: ReviewForm_1
+  },
 };
 
 export const staticBlockQuantities = Object.keys(
@@ -989,4 +1000,12 @@ export const staticBlockCategories: BlockCategory[] = [
       staticBlocksWithComponents["banking-5"],
     ],
   },
+  {
+  id: "reviewform",
+  title: "Review Form",
+  description: "Forms for collecting user reviews and feedback",
+  image: "https://asset.cloudinary.com/milopy/cc35507e488effc231c4b047373756c0",
+  keywords: ["review", "rating", "comment", "feedback", "ecommerce"],
+  blocks: [staticBlocksWithComponents["reviewform-1"]],
+}
 ];

--- a/src/vaults/blocks/reviewform/reviewform-1.tsx
+++ b/src/vaults/blocks/reviewform/reviewform-1.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { toast } from "sonner"
 
-export function ReviewForm() {
+export default function ReviewForm_1() {
   const [rating, setRating] = useState("")
   const [comment, setComment] = useState("")
   const [loading, setLoading] = useState(false)


### PR DESCRIPTION
### ✨ What’s new

This PR adds a new block component: `ReviewForm`, which allows users to submit a customer review with a rating and comment. It's ideal for ecommerce or feedback-driven apps.

### 📦 Features

- Select a rating from 1 to 5 (with labels)
- Write and submit a text review
- Validates that both fields are filled
- Uses Shadcn UI components
- Fully self-contained and reusable

### 📸 Preview

![image](https://github.com/user-attachments/assets/59fe56ac-82ba-4236-bed9-f08c59d6ef21)


### 🧠 Usage

```tsx
import { ReviewForm } from "@/components/blocks/review-form"

<ReviewForm />

### Note: 
The onSubmit behavior is mocked for now. In a real app, it should be replaced with an API call or mutation logic.

Looking forward to feedback! 😊